### PR TITLE
Add lastmessage support to conversation model

### DIFF
--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CarAndClassic\TalkJS\Models;
 
+use CarAndClassic\TalkJS\Models\Message;
+
 class Conversation
 {
     public string $id;
@@ -18,6 +20,8 @@ class Conversation
 
     public array $custom;
 
+    public Message $lastMessage;
+
     public array $participants;
 
     public int $createdAt;
@@ -30,6 +34,7 @@ class Conversation
         $this->photoUrl = $data['photoUrl'] ?? null;
         $this->welcomeMessages = $data['welcomeMessages'] ?? [];
         $this->custom = $data['custom'] ?? [];
+        $this->lastMessage = new Message($data['lastMessage']) ?? new Message();
         $this->participants = $data['participants'] ?? [];
         $this->createdAt = $data['createdAt'];
     }

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -20,7 +20,7 @@ class Conversation
 
     public array $custom;
 
-    public Message $lastMessage;
+    public ?Message $lastMessage;
 
     public array $participants;
 
@@ -34,7 +34,7 @@ class Conversation
         $this->photoUrl = $data['photoUrl'] ?? null;
         $this->welcomeMessages = $data['welcomeMessages'] ?? [];
         $this->custom = $data['custom'] ?? [];
-        $this->lastMessage = new Message($data['lastMessage']) ?? new Message();
+        $this->lastMessage = isset($data['lastMessage']) ? new Message($data['lastMessage']) : null;
         $this->participants = $data['participants'] ?? [];
         $this->createdAt = $data['createdAt'];
     }

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -20,8 +20,10 @@ class Message
     public ?array $attachment;
     public int $createdAt;
 
-    public function __construct(array $data)
+    public function __construct(array $data = [])
     {
+        if(empty($data)) return;
+
         $this->id = (string)$data['id'];
         $this->type = $data['type'];
         $this->senderId = $data['senderId'] ?? null;

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -20,10 +20,8 @@ class Message
     public ?array $attachment;
     public int $createdAt;
 
-    public function __construct(array $data = [])
+    public function __construct(array $data)
     {
-        if(empty($data)) return;
-
         $this->id = (string)$data['id'];
         $this->type = $data['type'];
         $this->senderId = $data['senderId'] ?? null;

--- a/tests/Feature/ConversationTest.php
+++ b/tests/Feature/ConversationTest.php
@@ -13,6 +13,7 @@ use CarAndClassic\TalkJS\Events\ConversationLeft;
 use CarAndClassic\TalkJS\Events\ConversationRead;
 use CarAndClassic\TalkJS\Events\ParticipationUpdated;
 use CarAndClassic\TalkJS\Models\Conversation;
+use CarAndClassic\TalkJS\Models\Message;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class ConversationTest extends TestCase
@@ -37,6 +38,21 @@ final class ConversationTest extends TestCase
                 'photoUrl' => null,
                 'welcomeMessages' => ['Test Welcome Message'],
                 'custom' => ['test' => 'test'],
+                'lastMessage' => new Message([
+                    'id' => "test",
+                    'type' => "UserMessage",
+                    'conversationId' => "dev_test",
+                    'senderId' => $this->userIds[1],
+                    'text' => "This is the message copy",
+                    'readBy' => [
+                        $this->userIds[0],
+                    ],
+                    'origin' => "rest",
+                    'location' => null,
+                    'custom' => [],
+                    'attachment' => null,
+                    'createdAt' => $createdAt,
+                ]),
                 'participants' => [
                      $this->userIds[0] => [
                         'access' => 'ReadWrite',
@@ -56,6 +72,7 @@ final class ConversationTest extends TestCase
                 'photoUrl' => null,
                 'welcomeMessages' => ['Test Welcome Message'],
                 'custom' => ['test' => 'test'],
+                'lastMessage' => null,
                 'participants' => [
                     $this->userIds[0] => [
                         'access' => 'ReadWrite',


### PR DESCRIPTION
Added a `lastMessage` property to the `Conversations` model that converts the `lastMessage` array that comes from the API to the `Message` Model and set to `null` if there is no `lastMessage` item that comes back.

Updated test to take in the `lastMessage` with `Message` model and with null fallback.