### PR TITLE
Incorrect ConversationAccess enum value for READ

### DIFF
--- a/src/Enumerations/ConversationAccess.php
+++ b/src/Enumerations/ConversationAccess.php
@@ -7,5 +7,5 @@ namespace CarAndClassic\TalkJS\Enumerations;
 final class ConversationAccess
 {
     public const READ_WRITE = 'ReadWrite';
-    public const READ = 'read';
+    public const READ = 'Read';
 }


### PR DESCRIPTION
According to [the documentation](https://talkjs.com/docs/Reference/REST_API/Participation/#join-conversation) it should be `Read` intead of `read`.